### PR TITLE
added \proofname and optional argument to proof environment

### DIFF
--- a/Banana/Text/Preamble.txt
+++ b/Banana/Text/Preamble.txt
@@ -241,7 +241,11 @@
     \begin{@proof}{###2}#1\end{@proof}%
   }%
 }
-\newproof{proof}{Proof}
+\def\proofname{Proof}
+\newproof{proof}{\proofname}
+\@textdef\@adefenv{proof}{[#1~]#2}{%
+  \begin{@proof}{#1}#2\end{@proof}%
+}
 
 \style{normal}
 


### PR DESCRIPTION
Hello,

I have create a patch which adds \proofname and optional argument to proof environment.
The added code is tested in this page: https://www.bananaspace.net/page/84363414

I hope this patch is useful.